### PR TITLE
Add simple Tkinter 3D window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # isoworld
 
-This repository contains a simple isometric world generator written in Python. It randomly generates height values for a grid of tiles and renders them using a basic ASCII isometric projection.
+This repository contains a small isometric world generator written in Python. It
+generates a grid of tiles with smoothed height, moisture and temperature values
+and renders them in a basic ASCII isometric projection. Terrain is derived from
+all three properties so worlds feature water, sand, desert, grass, forest,
+mountain, snow and additional biomes such as tundra, taiga, savanna and
+rainforest.
 
 ## Usage
 
 Run the main script:
 
 ```bash
-python main.py
+python main.py [--width N] [--height N] [--smoothing N]
+               [--algorithm {simple,fractal}] [--seed SEED]
+               [--moisture-seed SEED] [--temperature-seed SEED]
+               [--color] [--plot] [--window]
 ```
 
-The script prints an isometric view of the generated world to the console.
+The `--algorithm` option selects the height-map generator: the default "simple"
+algorithm averages random values, while `fractal` uses a diamond-square
+implementation for more natural terrain. `--seed`, `--moisture-seed` and
+`--temperature-seed` allow deterministic height, moisture and temperature maps
+respectively. Pass `--color` to render
+ANSI-colored tiles. Use `--plot` to also save a 3D height map to `world.png`
+(requires `matplotlib`). Use `--window` to open a simple interactive 3D view
+powered by `tkinter`.
 

--- a/isoworld/render.py
+++ b/isoworld/render.py
@@ -2,12 +2,48 @@ from typing import List
 from .world import Tile
 
 TILE_SYMBOLS = {
-    0: '. ',
-    1: 'o ',
-    2: '^ ',
+    "water": "~ ",
+    "sand": ". ",
+    "desert": "` ",
+    "grass": ", ",
+    "forest": "^ ",
+    "mountain": "A ",
+    "snow": "* ",
+    "tundra": ": ",
+    "taiga": "; ",
+    "savanna": "' ",
+    "rainforest": "! ",
 }
 
-def render_isometric(world: List[List[Tile]]) -> str:
+TILE_SYMBOLS_COLOR = {
+    "water": "\x1b[34m~ \x1b[0m",
+    "sand": "\x1b[33m. \x1b[0m",
+    "desert": "\x1b[33m` \x1b[0m",
+    "grass": "\x1b[32m, \x1b[0m",
+    "forest": "\x1b[32m^ \x1b[0m",
+    "mountain": "\x1b[37mA \x1b[0m",
+    "snow": "\x1b[37m* \x1b[0m",
+    "tundra": "\x1b[37m: \x1b[0m",
+    "taiga": "\x1b[32m; \x1b[0m",
+    "savanna": "\x1b[33m' \x1b[0m",
+    "rainforest": "\x1b[32m! \x1b[0m",
+}
+
+TILE_COLORS = {
+    "water": "#3b6efb",
+    "sand": "#d2b48c",
+    "desert": "#edc9af",
+    "grass": "#00aa00",
+    "forest": "#228b22",
+    "mountain": "#777777",
+    "snow": "#ffffff",
+    "tundra": "#cccccc",
+    "taiga": "#006400",
+    "savanna": "#bdb76b",
+    "rainforest": "#005500",
+}
+
+def render_isometric(world: List[List[Tile]], color: bool = False) -> str:
     """Render the world in a simple isometric ASCII representation."""
     height = len(world)
     width = len(world[0]) if world else 0
@@ -17,7 +53,95 @@ def render_isometric(world: List[List[Tile]]) -> str:
         line_parts = [offset]
         for x in range(width):
             tile = world[y][x]
-            symbol = TILE_SYMBOLS.get(tile.height, '? ')
+            symbols = TILE_SYMBOLS_COLOR if color else TILE_SYMBOLS
+            symbol = symbols.get(tile.terrain, '? ')
             line_parts.append(symbol)
         lines.append(''.join(line_parts))
     return '\n'.join(lines)
+
+
+def render_3d_plot(world: List[List[Tile]], filename: str = "world.png") -> str:
+    """Render the world as a 3D height map saved to an image file."""
+    try:
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("matplotlib is required for 3D rendering") from exc
+
+    height = len(world)
+    width = len(world[0]) if world else 0
+    z_values = [[tile.height for tile in row] for row in world]
+    x_values, y_values = np.meshgrid(range(width), range(height))
+    z_array = np.array(z_values)
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    ax.plot_surface(x_values, y_values, z_array, cmap="terrain", edgecolor="k")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel("height")
+    plt.savefig(filename)
+    plt.close(fig)
+    return filename
+
+
+def _shade_color(color: str, factor: float) -> str:
+    """Return a darker shade of the given hex color."""
+    if not color.startswith("#") or len(color) != 7:
+        return color
+    r = int(color[1:3], 16)
+    g = int(color[3:5], 16)
+    b = int(color[5:7], 16)
+    r = int(r * factor)
+    g = int(g * factor)
+    b = int(b * factor)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def render_3d_window(world: List[List[Tile]]) -> None:
+    """Display a simple 3D view of the world using tkinter."""
+    try:
+        import tkinter as tk
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("tkinter is required for window rendering") from exc
+
+    tile_w = 30
+    tile_h = 15
+    tile_d = 10
+    width = len(world[0]) if world else 0
+    height = len(world)
+    x_offset = width * tile_w
+    y_offset = 50
+    max_h = max(tile.height for row in world for tile in row)
+    canvas_w = (width + height) * tile_w + x_offset
+    canvas_h = (width + height) * tile_h // 2 + max_h * tile_d + y_offset * 2
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - headless environments
+        raise RuntimeError("tkinter failed to initialize") from exc
+    root.title("isoworld 3D")
+    canvas = tk.Canvas(root, width=canvas_w, height=canvas_h, bg="white")
+    canvas.pack()
+
+    def iso(x: int, y: int, z: int) -> tuple[int, int]:
+        sx = (x - y) * tile_w + x_offset
+        sy = (x + y) * tile_h // 2 - z * tile_d + y_offset
+        return sx, sy
+
+    def draw_block(x: int, y: int, h: int, terrain: str) -> None:
+        color = TILE_COLORS.get(terrain, "#808080")
+        top = [iso(x, y, h), iso(x + 1, y, h), iso(x + 1, y + 1, h), iso(x, y + 1, h)]
+        left = [iso(x, y + 1, 0), iso(x, y, 0), iso(x, y, h), iso(x, y + 1, h)]
+        right = [iso(x + 1, y, 0), iso(x + 1, y + 1, 0), iso(x + 1, y + 1, h), iso(x + 1, y, h)]
+        canvas.create_polygon(right, fill=_shade_color(color, 0.7), outline="black")
+        canvas.create_polygon(left, fill=_shade_color(color, 0.85), outline="black")
+        canvas.create_polygon(top, fill=color, outline="black")
+
+    for y in range(height - 1, -1, -1):
+        for x in range(width):
+            tile = world[y][x]
+            draw_block(x, y, tile.height, tile.terrain)
+
+    root.mainloop()

--- a/isoworld/world.py
+++ b/isoworld/world.py
@@ -3,19 +3,170 @@ from typing import List
 
 class Tile:
     """Represents a tile in the world."""
-    def __init__(self, height: int):
+
+    def __init__(self, height: int, moisture: int, temperature: int):
         self.height = height
+        self.moisture = moisture
+        self.temperature = temperature
 
     def __repr__(self) -> str:
-        return f"Tile(height={self.height})"
+        return (
+            f"Tile(height={self.height}, moisture={self.moisture}, "
+            f"temperature={self.temperature})"
+        )
+
+    @property
+    def terrain(self) -> str:
+        """Return a terrain type based on height, moisture and temperature."""
+        if self.height <= 0:
+            return "water"
+
+        if self.height >= 4:
+            return "snow" if self.temperature <= 1 else "mountain"
+
+        if self.moisture <= 1:
+            return "desert" if self.temperature >= 2 else "tundra"
+
+        if self.moisture >= 3:
+            return "rainforest" if self.temperature >= 3 else "forest"
+
+        # Moderate moisture
+        if self.temperature >= 3:
+            return "savanna"
+        if self.temperature <= 1:
+            return "taiga"
+        return "grass"
 
 
-def generate_height_map(width: int, height: int) -> List[List[int]]:
-    """Generate a height map using simple random values."""
-    return [[random.randint(0, 2) for _ in range(width)] for _ in range(height)]
+def generate_height_map(width: int, height: int, smoothing: int = 1, seed: int | None = None) -> List[List[int]]:
+    """Generate a height map using a basic smoothing algorithm."""
+    rng = random.Random(seed)
+    height_map = [[rng.randint(0, 4) for _ in range(width)] for _ in range(height)]
+
+    for _ in range(smoothing):
+        new_map = [[0 for _ in range(width)] for _ in range(height)]
+        for y in range(height):
+            for x in range(width):
+                neighbors = []
+                for dy in (-1, 0, 1):
+                    for dx in (-1, 0, 1):
+                        ny, nx = y + dy, x + dx
+                        if 0 <= ny < height and 0 <= nx < width:
+                            neighbors.append(height_map[ny][nx])
+                new_map[y][x] = round(sum(neighbors) / len(neighbors))
+        height_map = new_map
+
+    return height_map
 
 
-def generate_world(width: int, height: int) -> List[List[Tile]]:
+def generate_moisture_map(width: int, height: int, smoothing: int = 1, seed: int | None = None) -> List[List[int]]:
+    """Generate a moisture map using the same algorithm as heights."""
+    return generate_height_map(width, height, smoothing=smoothing, seed=seed)
+
+
+def generate_temperature_map(
+    width: int, height: int, smoothing: int = 1, seed: int | None = None
+) -> List[List[int]]:
+    """Generate a temperature map using the same algorithm as heights."""
+    return generate_height_map(width, height, smoothing=smoothing, seed=seed)
+
+
+def _next_power_of_two(n: int) -> int:
+    """Return the next power of two greater than or equal to n."""
+    return 1 << (n - 1).bit_length()
+
+
+def generate_height_map_fractal(width: int, height: int, roughness: float = 1.0, seed: int | None = None) -> List[List[int]]:
+    """Generate a height map using the diamond-square algorithm."""
+    rng = random.Random(seed)
+
+    size = _next_power_of_two(max(width, height)) + 1
+    grid = [[0.0 for _ in range(size)] for _ in range(size)]
+
+    grid[0][0] = grid[0][-1] = grid[-1][0] = grid[-1][-1] = rng.random()
+
+    step = size - 1
+    scale = roughness
+    while step > 1:
+        half = step // 2
+        # Diamond step
+        for y in range(half, size - 1, step):
+            for x in range(half, size - 1, step):
+                avg = (
+                    grid[y - half][x - half]
+                    + grid[y - half][x + half]
+                    + grid[y + half][x - half]
+                    + grid[y + half][x + half]
+                ) / 4.0
+                grid[y][x] = avg + (rng.random() - 0.5) * scale
+
+        # Square step
+        for y in range(0, size, half):
+            for x in range((y + half) % step, size, step):
+                vals = []
+                if y - half >= 0:
+                    vals.append(grid[y - half][x])
+                if y + half < size:
+                    vals.append(grid[y + half][x])
+                if x - half >= 0:
+                    vals.append(grid[y][x - half])
+                if x + half < size:
+                    vals.append(grid[y][x + half])
+                grid[y][x] = sum(vals) / len(vals) + (rng.random() - 0.5) * scale
+
+        step = half
+        scale /= 2.0
+
+    # Normalize 0..1
+    min_v = min(min(row) for row in grid)
+    max_v = max(max(row) for row in grid)
+    for y in range(size):
+        for x in range(size):
+            grid[y][x] = (grid[y][x] - min_v) / (max_v - min_v)
+
+    height_map = [
+        [int(round(grid[y][x] * 4)) for x in range(width)]
+        for y in range(height)
+    ]
+    return height_map
+
+
+def generate_moisture_map_fractal(width: int, height: int, roughness: float = 1.0, seed: int | None = None) -> List[List[int]]:
+    """Generate a moisture map using the diamond-square algorithm."""
+    return generate_height_map_fractal(width, height, roughness=roughness, seed=seed)
+
+
+def generate_temperature_map_fractal(
+    width: int, height: int, roughness: float = 1.0, seed: int | None = None
+) -> List[List[int]]:
+    """Generate a temperature map using the diamond-square algorithm."""
+    return generate_height_map_fractal(width, height, roughness=roughness, seed=seed)
+
+
+def generate_world(
+    width: int,
+    height: int,
+    smoothing: int = 2,
+    algorithm: str = "simple",
+    seed: int | None = None,
+    moisture_seed: int | None = None,
+    temperature_seed: int | None = None,
+) -> List[List[Tile]]:
     """Generate the world as a 2D grid of tiles."""
-    height_map = generate_height_map(width, height)
-    return [[Tile(h) for h in row] for row in height_map]
+    if algorithm == "fractal":
+        height_map = generate_height_map_fractal(width, height, seed=seed)
+        moisture_map = generate_moisture_map_fractal(width, height, seed=moisture_seed)
+        temperature_map = generate_temperature_map_fractal(
+            width, height, seed=temperature_seed
+        )
+    else:
+        height_map = generate_height_map(width, height, smoothing=smoothing, seed=seed)
+        moisture_map = generate_moisture_map(width, height, smoothing=smoothing, seed=moisture_seed)
+        temperature_map = generate_temperature_map(
+            width, height, smoothing=smoothing, seed=temperature_seed
+        )
+
+    world = []
+    for h_row, m_row, t_row in zip(height_map, moisture_map, temperature_map):
+        world.append([Tile(h, m, t) for h, m, t in zip(h_row, m_row, t_row)])
+    return world

--- a/main.py
+++ b/main.py
@@ -1,8 +1,48 @@
+import argparse
 from isoworld.world import generate_world
-from isoworld.render import render_isometric
+from isoworld.render import render_isometric, render_3d_plot, render_3d_window
 
 if __name__ == "__main__":
-    width = 10
-    height = 10
-    world = generate_world(width, height)
-    print(render_isometric(world))
+    parser = argparse.ArgumentParser(description="Generate and render an isometric world")
+    parser.add_argument("--width", type=int, default=10, help="world width")
+    parser.add_argument("--height", type=int, default=10, help="world height")
+    parser.add_argument("--smoothing", type=int, default=2, help="smoothing rounds")
+    parser.add_argument(
+        "--algorithm",
+        choices=["simple", "fractal"],
+        default="simple",
+        help="height generation algorithm",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="random seed")
+    parser.add_argument(
+        "--moisture-seed", type=int, default=None, help="seed for moisture map"
+    )
+    parser.add_argument(
+        "--temperature-seed", type=int, default=None, help="seed for temperature map"
+    )
+    parser.add_argument("--color", action="store_true", help="use ANSI colors")
+    parser.add_argument("--plot", action="store_true", help="save a 3D plot to world.png")
+    parser.add_argument("--window", action="store_true", help="display a 3D window")
+    args = parser.parse_args()
+
+    world = generate_world(
+        args.width,
+        args.height,
+        smoothing=args.smoothing,
+        algorithm=args.algorithm,
+        seed=args.seed,
+        moisture_seed=args.moisture_seed,
+        temperature_seed=args.temperature_seed,
+    )
+    print(render_isometric(world, color=args.color))
+    if args.window:
+        try:
+            render_3d_window(world)
+        except RuntimeError as exc:
+            print(exc)
+    if args.plot:
+        try:
+            path = render_3d_plot(world)
+            print(f"Saved 3D plot to {path}")
+        except RuntimeError as exc:
+            print(exc)


### PR DESCRIPTION
## Summary
- add hex color definitions for terrains
- implement `render_3d_window` using tkinter
- expose new `--window` CLI flag and document it

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --width 5 --height 5 --algorithm fractal --seed 1 --moisture-seed 2 --temperature-seed 3 --color`
- `python main.py --width 5 --height 5 --algorithm fractal --seed 1 --moisture-seed 2 --temperature-seed 3 --plot`
- `python main.py --width 2 --height 2 --window`

------
https://chatgpt.com/codex/tasks/task_e_6840c92d8420832c97a7c95c6c2d0e49