### PR TITLE
Fix gaps in tkinter rendering

### DIFF
--- a/isoworld/render.py
+++ b/isoworld/render.py
@@ -125,10 +125,10 @@ def render_3d_window(world: List[List[Tile]]) -> None:
     canvas = tk.Canvas(root, width=canvas_w, height=canvas_h, bg="white")
     canvas.pack()
 
-    def iso(x: int, y: int, z: int) -> tuple[int, int]:
+    def iso(x: int, y: int, z: int) -> tuple[float, float]:
         sx = (x - y) * tile_w + x_offset
         sy = (x + y) * tile_h * 0.5 - z * tile_d + y_offset
-        return round(sx), round(sy)
+        return sx, sy
 
     def draw_block(x: int, y: int, h: int, terrain: str) -> None:
         color = TILE_COLORS.get(terrain, "#808080")


### PR DESCRIPTION
## Summary
- prevent rounding error when converting 3D coordinates to screen space

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416201833c832cb06bde70a11ecc72