### PR TITLE
Fix indentation issue in Tkinter renderer

### DIFF
--- a/isoworld/render.py
+++ b/isoworld/render.py
@@ -185,6 +185,11 @@ def render_3d_window(world: List[List[Tile]]) -> None:
     coords = []
     for y in range(height):
         for x in range(width):
+            world_y = height - y - 1
+            coords.append((x, world_y, x + world_y))
 
+    for x, y, _ in sorted(coords, key=lambda c: c[2]):
+        tile = world[y][x]
+        draw_block(x, y)
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- fix incomplete block and indentation in `render.py`

## Testing
- `python main.py --help`
- `python main.py --width 5 --height 5`

------
https://chatgpt.com/codex/tasks/task_e_68416c7fdcb8832c8da71e8a131fc811